### PR TITLE
fix: Supabaseデプロイワークフローのコマンド修正と環境変数取得方法の改善

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -31,55 +31,19 @@ jobs:
         id: set-env
         run: |
           if [[ $GITHUB_REF == 'refs/heads/dev' ]]; then
-            # GitHub Secretsが設定されている場合はそれを使用
-            if [[ -n "${{ secrets.DEV_SUPABASE_PROJECT_ID }}" ]]; then
-              echo "SUPABASE_PROJECT_ID=${{ secrets.DEV_SUPABASE_PROJECT_ID }}" >> $GITHUB_ENV
-            else
-              # 環境変数ファイルの存在確認
-              if [[ ! -f "digeclip/.env.development" ]]; then
-                echo "Error: digeclip/.env.development ファイルが見つかりません。"
-                exit 1
-              fi
-              # 環境変数ファイルからプロジェクトIDを抽出
-              DEV_SUPABASE_URL=$(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.development | cut -d'"' -f2)
-              DEV_PROJECT_ID=$(echo $DEV_SUPABASE_URL | sed 's/https:\/\///' | sed 's/.supabase.co//')
-              echo "SUPABASE_PROJECT_ID=$DEV_PROJECT_ID" >> $GITHUB_ENV
-            fi
-
+            # GitHub Secretsから開発環境のプロジェクトIDを設定
+            echo "SUPABASE_PROJECT_ID=${{ secrets.DEV_SUPABASE_PROJECT_ID }}" >> $GITHUB_ENV
             echo "SUPABASE_ACCESS_TOKEN=${{ secrets.SUPABASE_ACCESS_TOKEN }}" >> $GITHUB_ENV
             echo "APPLY_SEED=true" >> $GITHUB_ENV
             echo "環境: 開発環境 (シードデータ適用あり)" >> $GITHUB_STEP_SUMMARY
-            # ファイルが存在する場合のみURLを表示
-            if [[ -f "digeclip/.env.development" ]]; then
-              echo "Supabase URL: $(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.development | cut -d'"' -f2)" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "Supabase URL: 環境変数から取得 (${{ secrets.DEV_SUPABASE_PROJECT_ID }})" >> $GITHUB_STEP_SUMMARY
-            fi
+            echo "Supabase Project ID: ${{ secrets.DEV_SUPABASE_PROJECT_ID }}" >> $GITHUB_STEP_SUMMARY
           elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
-            # GitHub Secretsが設定されている場合はそれを使用
-            if [[ -n "${{ secrets.PROD_SUPABASE_PROJECT_ID }}" ]]; then
-              echo "SUPABASE_PROJECT_ID=${{ secrets.PROD_SUPABASE_PROJECT_ID }}" >> $GITHUB_ENV
-            else
-              # 環境変数ファイルの存在確認
-              if [[ ! -f "digeclip/.env.production" ]]; then
-                echo "Error: digeclip/.env.production ファイルが見つかりません。"
-                exit 1
-              fi
-              # 環境変数ファイルからプロジェクトIDを抽出
-              PROD_SUPABASE_URL=$(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.production | cut -d'"' -f2)
-              PROD_PROJECT_ID=$(echo $PROD_SUPABASE_URL | sed 's/https:\/\///' | sed 's/.supabase.co//')
-              echo "SUPABASE_PROJECT_ID=$PROD_PROJECT_ID" >> $GITHUB_ENV
-            fi
-
+            # GitHub Secretsから本番環境のプロジェクトIDを設定
+            echo "SUPABASE_PROJECT_ID=${{ secrets.PROD_SUPABASE_PROJECT_ID }}" >> $GITHUB_ENV
             echo "SUPABASE_ACCESS_TOKEN=${{ secrets.SUPABASE_ACCESS_TOKEN }}" >> $GITHUB_ENV
             echo "APPLY_SEED=false" >> $GITHUB_ENV
             echo "環境: 本番環境 (スキーマのみ適用、シードデータなし)" >> $GITHUB_STEP_SUMMARY
-            # ファイルが存在する場合のみURLを表示
-            if [[ -f "digeclip/.env.production" ]]; then
-              echo "Supabase URL: $(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.production | cut -d'"' -f2)" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "Supabase URL: 環境変数から取得 (${{ secrets.PROD_SUPABASE_PROJECT_ID }})" >> $GITHUB_STEP_SUMMARY
-            fi
+            echo "Supabase Project ID: ${{ secrets.PROD_SUPABASE_PROJECT_ID }}" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: スキーマをデプロイ

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -35,6 +35,11 @@ jobs:
             if [[ -n "${{ secrets.DEV_SUPABASE_PROJECT_ID }}" ]]; then
               echo "SUPABASE_PROJECT_ID=${{ secrets.DEV_SUPABASE_PROJECT_ID }}" >> $GITHUB_ENV
             else
+              # 環境変数ファイルの存在確認
+              if [[ ! -f "digeclip/.env.development" ]]; then
+                echo "Error: digeclip/.env.development ファイルが見つかりません。"
+                exit 1
+              fi
               # 環境変数ファイルからプロジェクトIDを抽出
               DEV_SUPABASE_URL=$(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.development | cut -d'"' -f2)
               DEV_PROJECT_ID=$(echo $DEV_SUPABASE_URL | sed 's/https:\/\///' | sed 's/.supabase.co//')
@@ -44,12 +49,22 @@ jobs:
             echo "SUPABASE_ACCESS_TOKEN=${{ secrets.SUPABASE_ACCESS_TOKEN }}" >> $GITHUB_ENV
             echo "APPLY_SEED=true" >> $GITHUB_ENV
             echo "環境: 開発環境 (シードデータ適用あり)" >> $GITHUB_STEP_SUMMARY
-            echo "Supabase URL: $(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.development | cut -d'"' -f2)" >> $GITHUB_STEP_SUMMARY
+            # ファイルが存在する場合のみURLを表示
+            if [[ -f "digeclip/.env.development" ]]; then
+              echo "Supabase URL: $(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.development | cut -d'"' -f2)" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "Supabase URL: 環境変数から取得 (${{ secrets.DEV_SUPABASE_PROJECT_ID }})" >> $GITHUB_STEP_SUMMARY
+            fi
           elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
             # GitHub Secretsが設定されている場合はそれを使用
             if [[ -n "${{ secrets.PROD_SUPABASE_PROJECT_ID }}" ]]; then
               echo "SUPABASE_PROJECT_ID=${{ secrets.PROD_SUPABASE_PROJECT_ID }}" >> $GITHUB_ENV
             else
+              # 環境変数ファイルの存在確認
+              if [[ ! -f "digeclip/.env.production" ]]; then
+                echo "Error: digeclip/.env.production ファイルが見つかりません。"
+                exit 1
+              fi
               # 環境変数ファイルからプロジェクトIDを抽出
               PROD_SUPABASE_URL=$(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.production | cut -d'"' -f2)
               PROD_PROJECT_ID=$(echo $PROD_SUPABASE_URL | sed 's/https:\/\///' | sed 's/.supabase.co//')
@@ -59,11 +74,22 @@ jobs:
             echo "SUPABASE_ACCESS_TOKEN=${{ secrets.SUPABASE_ACCESS_TOKEN }}" >> $GITHUB_ENV
             echo "APPLY_SEED=false" >> $GITHUB_ENV
             echo "環境: 本番環境 (スキーマのみ適用、シードデータなし)" >> $GITHUB_STEP_SUMMARY
-            echo "Supabase URL: $(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.production | cut -d'"' -f2)" >> $GITHUB_STEP_SUMMARY
+            # ファイルが存在する場合のみURLを表示
+            if [[ -f "digeclip/.env.production" ]]; then
+              echo "Supabase URL: $(grep NEXT_PUBLIC_SUPABASE_URL digeclip/.env.production | cut -d'"' -f2)" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "Supabase URL: 環境変数から取得 (${{ secrets.PROD_SUPABASE_PROJECT_ID }})" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
 
       - name: スキーマをデプロイ
         run: |
+          # スキーマファイルの存在確認
+          if [[ ! -f "digeclip/seeds/dev_schema.sql" ]]; then
+            echo "Error: digeclip/seeds/dev_schema.sql ファイルが見つかりません。"
+            exit 1
+          fi
+
           # 両環境ともにスキーマを適用
           cat digeclip/seeds/dev_schema.sql | supabase db query --project-ref $SUPABASE_PROJECT_ID
 
@@ -76,6 +102,12 @@ jobs:
       - name: 開発環境にシードデータを適用
         if: env.APPLY_SEED == 'true'
         run: |
+          # シードファイルの存在確認
+          if [[ ! -f "digeclip/seeds/dev_seed.sql" ]]; then
+            echo "Error: digeclip/seeds/dev_seed.sql ファイルが見つかりません。"
+            exit 1
+          fi
+
           echo "開発環境用シードデータを適用します"
           cat digeclip/seeds/dev_seed.sql | supabase db query --project-ref $SUPABASE_PROJECT_ID
           echo "開発環境用シードデータを適用しました" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -65,7 +65,7 @@ jobs:
       - name: スキーマをデプロイ
         run: |
           # 両環境ともにスキーマを適用
-          cat digeclip/seeds/dev_schema.sql | supabase db execute --project-id $SUPABASE_PROJECT_ID
+          cat digeclip/seeds/dev_schema.sql | supabase db query --project-ref $SUPABASE_PROJECT_ID
 
           if [[ $GITHUB_REF == 'refs/heads/dev' ]]; then
             echo "開発環境用スキーマを適用しました" >> $GITHUB_STEP_SUMMARY
@@ -77,5 +77,5 @@ jobs:
         if: env.APPLY_SEED == 'true'
         run: |
           echo "開発環境用シードデータを適用します"
-          cat digeclip/seeds/dev_seed.sql | supabase db execute --project-id $SUPABASE_PROJECT_ID
+          cat digeclip/seeds/dev_seed.sql | supabase db query --project-ref $SUPABASE_PROJECT_ID
           echo "開発環境用シードデータを適用しました" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 概要
GitHubワークフローのSupabaseデプロイ処理が失敗していたため、コマンド構文と環境変数の取得方法を修正しました。

## 変更内容
- Supabase CLIの構文を修正（`execute --project-id` → `query --project-ref`）
- 環境変数取得方法を改善し、常にGitHub Secretsから取得するよう変更
- SQLファイルの存在確認を追加し、エラーメッセージを明確化

### スクリーンショット（UI変更の場合）
<!-- UI変更はありません -->

## 今後の作業
- ワークフローの実行を確認し、正常に動作することを検証

## 関連課題
- #71 

## チェックリスト
- [x] コーディング規約に準拠している
- [ ] 適切なテストを追加している
- [x] ドキュメントを更新している
- [ ] UIコンポーネントの場合、レスポンシブデザインに対応している
- [ ] アクセシビリティに配慮している
- [ ] パフォーマンスへの影響を考慮している
