### PR TITLE
Supabaseデプロイワークフローのコマンドエラー修正

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           version: latest
 
+      - name: PostgreSQLクライアントをインストール
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
       - name: 環境変数を設定
         id: set-env
         run: |
@@ -60,7 +65,8 @@ jobs:
 
           # 両環境ともにスキーマを適用
           CONNECTION_STRING="postgresql://${DB_USER}:${DB_PASSWORD}@db.${SUPABASE_PROJECT_ID}.supabase.co:5432/postgres"
-          supabase db execute -f digeclip/seeds/dev_schema.sql --connection-string "$CONNECTION_STRING"
+          # ここでpsqlコマンドを使用してSQLファイルを実行
+          PGPASSWORD="${DB_PASSWORD}" psql "sslmode=require host=db.${SUPABASE_PROJECT_ID}.supabase.co port=5432 user=${DB_USER} dbname=postgres" -f digeclip/seeds/dev_schema.sql
 
           if [[ $GITHUB_REF == 'refs/heads/dev' ]]; then
             echo "開発環境用スキーマを適用しました" >> $GITHUB_STEP_SUMMARY
@@ -78,6 +84,6 @@ jobs:
           fi
 
           echo "開発環境用シードデータを適用します"
-          CONNECTION_STRING="postgresql://${DB_USER}:${DB_PASSWORD}@db.${SUPABASE_PROJECT_ID}.supabase.co:5432/postgres"
-          supabase db execute -f digeclip/seeds/dev_seed.sql --connection-string "$CONNECTION_STRING"
+          # ここでpsqlコマンドを使用してシードSQLファイルを実行
+          PGPASSWORD="${DB_PASSWORD}" psql "sslmode=require host=db.${SUPABASE_PROJECT_ID}.supabase.co port=5432 user=${DB_USER} dbname=postgres" -f digeclip/seeds/dev_seed.sql
           echo "開発環境用シードデータを適用しました" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 概要
GitHub ActionsのSupabaseデプロイワークフローでエラーが発生していた問題を修正しました。Supabase CLIの `db execute -f` コマンドが認識されていなかったため、標準的なPostgreSQLクライアント（psql）を使用する方法に変更しました。

## 変更内容
- supabase db execute -fコマンドをpsqlコマンドに置き換え
- PostgreSQLクライアントをインストールするステップを追加
- SSL接続の設定を追加（sslmode=require）
- 接続文字列を最適化

## 今後の作業
特になし

## 関連課題
- #71 

## チェックリスト
- [x] コーディング規約に準拠している
- [ ] 適切なテストを追加している
- [x] ドキュメントを更新している
- [ ] UIコンポーネントの場合、レスポンシブデザインに対応している
- [ ] アクセシビリティに配慮している
- [ ] パフォーマンスへの影響を考慮している