### PR TITLE
fix: Supabaseデプロイワークフローのpsqlコマンドエラーを修正

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -76,7 +76,7 @@ jobs:
 
           # スキーマを適用
           echo "psqlコマンドを実行中..."
-          PGOPTIONS="-c client_min_messages=warning" psql -v ON_ERROR_STOP=1 -4 "sslmode=require host=$DB_HOST port=5432 user=$DB_USER dbname=postgres" -f digeclip/seeds/dev_schema.sql
+          PGOPTIONS="-c client_min_messages=warning" psql -v ON_ERROR_STOP=1 "sslmode=require host=$DB_HOST port=5432 user=$DB_USER dbname=postgres" -f digeclip/seeds/dev_schema.sql
           echo "スキーマを適用しました" >> $GITHUB_STEP_SUMMARY
 
           # シードデータの適用（開発環境のみ）
@@ -87,6 +87,6 @@ jobs:
             fi
 
             echo "シードデータを適用しています..."
-            PGOPTIONS="-c client_min_messages=warning" psql -v ON_ERROR_STOP=1 -4 "sslmode=require host=$DB_HOST port=5432 user=$DB_USER dbname=postgres" -f digeclip/seeds/dev_seed.sql
+            PGOPTIONS="-c client_min_messages=warning" psql -v ON_ERROR_STOP=1 "sslmode=require host=$DB_HOST port=5432 user=$DB_USER dbname=postgres" -f digeclip/seeds/dev_seed.sql
             echo "シードデータを適用しました" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
## 概要
<!-- 変更の目的や背景を簡潔に説明してください -->
GitHub Actionsのワークフローでpsqlコマンドに無効なオプション（-4）が指定されていたため、Supabaseデプロイが失敗していました。このPRでは該当オプションを削除し、デプロイワークフローを修正します。

## 変更内容
<!-- 具体的な変更点を箇条書きで記載してください -->
- `.github/workflows/supabase-deploy.yml`ファイル内のpsqlコマンドから無効な`-4`オプションを削除
- スキーマ適用とシードデータ適用の両方で同様の修正を実施

### スクリーンショット（UI変更の場合）
<!-- UI変更を行った場合は、変更前後のスクリーンショットを添付してください -->
該当なし

## 今後の作業
<!-- このPR後に予定されている作業や残タスクがあれば記載してください -->
特になし。この修正によりデプロイワークフローが正常に実行されることを確認します。

## 関連課題
<!-- 関連するIssue番号を記載してください（例: #123） -->
- なし（CI/CDパイプラインエラーへの対応）

## チェックリスト
<!-- 該当する項目にxを入れてください [x] -->
- [x] コーディング規約に準拠している
- [ ] 適切なテストを追加している (CI/CDパイプラインの実行で検証)
- [ ] ドキュメントを更新している (該当なし)
- [ ] UIコンポーネントの場合、レスポンシブデザインに対応している (該当なし)
- [ ] アクセシビリティに配慮している (該当なし)
- [ ] パフォーマンスへの影響を考慮している (該当なし)