### PR TITLE
fix: Supabase CLIのインストール方法をサポートされている方式に変更

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -29,7 +29,9 @@ jobs:
           cache: 'npm'
 
       - name: Supabase CLIをインストール
-        run: npm install -g supabase
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
 
       - name: 環境変数の設定と適用
         run: |


### PR DESCRIPTION
## 概要
GitHub Actionsのワークフローで、Supabase CLIのインストール時にエラーが発生していました。公式ではnpmグローバルインストールがサポートされておらず、推奨インストール方法を使用するように修正しました。

## 変更内容
- npmグローバルインストール (`npm install -g supabase`) を削除
- 公式がサポートする `supabase/setup-cli@v1` GitHub Actionを使用するように変更
- 最新版を使用するため、バージョンは `latest` を指定

### エラー内容
```
npm error Installing Supabase CLI as a global module is not supported.
npm error Please use one of the supported package managers: https://github.com/supabase/cli#install-the-cli
```

## 今後の作業
- 次回のワークフロー実行時に正常に動作することを確認

## 関連課題
- なし

## チェックリスト
- [x] コーディング規約に準拠している
- [ ] 適切なテストを追加している
- [ ] ドキュメントを更新している
- [ ] UIコンポーネントの場合、レスポンシブデザインに対応している
- [ ] アクセシビリティに配慮している
- [ ] パフォーマンスへの影響を考慮している
```
